### PR TITLE
Move uploaded files to archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 
 -->
-## [v2.4.3](https://github.com/TUDelftGeodesy/caroline/tree/main) (08-Jul-2025, [diff](https://github.com/TUDelftGeodesy/caroline/compare/01e0d9d201657723ecd2b2bf044e662752d60536...main))
+## [v2.4.4](https://github.com/TUDelftGeodesy/caroline/tree/main) (09-Jul-2025, [diff](https://github.com/TUDelftGeodesy/caroline/compare/6352102043d95557d1bbdd025c62953eee8bdb18...main))
+
+### Fixed:
+- Portal layers that are uploaded to the SkyGeo portal are now moved away from the limited storage on `\tmp` to an archive directory with more space after they have been added to the correct portal
+
+## [v2.4.3](https://github.com/TUDelftGeodesy/caroline/tree/6352102043d95557d1bbdd025c62953eee8bdb18) (08-Jul-2025, [diff](https://github.com/TUDelftGeodesy/caroline/compare/01e0d9d201657723ecd2b2bf044e662752d60536...6352102043d95557d1bbdd025c62953eee8bdb18))
 
 ### Added:
 - `id_jakarta_short` AoI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "Caroline"
-version = "2.4.3"
+version = "2.4.4"
 requires-python = ">=3.10"
 dependencies = [
     "apache-airflow",

--- a/scripts/upload-result-csv-to-skygeo.sh
+++ b/scripts/upload-result-csv-to-skygeo.sh
@@ -15,6 +15,7 @@ fi
 
 SKYGEO_SERVER='portal-tud.skygeo.com'
 SKYGEO_UPLOAD_PATH='/tmp'
+SKYGEO_ARCHIVE='/home/caroline/upload_archive'
 #
 # Find the json metadata file. This only works if there is just one json file in the dir,
 # which currently is the case. We make sure we only get one file in the result by running
@@ -71,5 +72,10 @@ if [ "$(echo ${VIEWER} | wc -c)" -eq "0" ]; then  # viewer does not exist
 fi
 
 ssh "${SKYGEO_USER}"@"${SKYGEO_SERVER}" "pmantud add_viewer_data_layer ${SKYGEO_UPLOAD_PATH}/${CSV_FILE} ${CSV_FILE%.csv} ${SKYGEO_CUSTOMER} ${SKYGEO_VIEWER}"
+
+# Cleanup file from /tmp
+ssh "${SKYGEO_USER}"@"${SKYGEO_SERVER}" "find ${SKYGEO_UPLOAD_PATH} -user ${SKYGEO_USER} -name \"*uploaded*.csv\" -exec mv {} ${SKYGEO_ARCHIVE} \;"
+ssh "${SKYGEO_USER}"@"${SKYGEO_SERVER}" "find ${SKYGEO_UPLOAD_PATH} -user ${SKYGEO_USER} -name \"*uploaded*.json\" -exec mv {} ${SKYGEO_ARCHIVE} \;"
+#
 #
 # Eof


### PR DESCRIPTION
This should move uploaded files to the archive directory so that /tmp does not fill up.